### PR TITLE
cancel read after timeout

### DIFF
--- a/NModbusAsync/IO/PipeAdapter.cs
+++ b/NModbusAsync/IO/PipeAdapter.cs
@@ -123,10 +123,11 @@ namespace NModbusAsync.IO
 
             if (!readTask.IsCompleted && !await readTask.AsTask().WaitAsync(ReadTimeout, token).ConfigureAwait(false))
             {
+                pipeReader.CancelPendingRead();
                 throw new TimeoutException("Failed to read from the transport connection in specified period of time.");
             }
 
-            return readTask.Result;
+            return await readTask;
         }
     }
 }


### PR DESCRIPTION
I tested your library with the following setup:
One modbus rtu device (intensis) listening at ip xx.yy.zz.tt, with 10 slave ids on the bus, out of which id 4 is not responding.

When I try to read a register, with a set timeout of 5000ms and 3 retries, it works for ids 1, 2 and 3, then 4 times out (as it should), then all ids after 4 time out too (although they are responding if I don't include id 4 in the read list).

But with the added call pipeReader.CancelPendingRead() in case of timeout, the reading works properly (meaning only 4 times out, all other ids work).